### PR TITLE
Setting default thumbnail when no banner image is present for recent articles

### DIFF
--- a/layouts/partials/widgets/recent_articles.html
+++ b/layouts/partials/widgets/recent_articles.html
@@ -12,7 +12,7 @@
                     {{ if isset .Params "banner" }}
                         <span style="background-image:url({{ $.Site.BaseURL }}{{ .Params.banner }})" alt="{{ $.Title }}" class="thumbnail-image"></span>
                     {{else}}
-                        <span style="background-image:url({{ .Site.BaseURL }}css/images/thumb-default-small.png)" alt="{{ $.Title }}" class="thumbnail-image"></span>
+                        <span class="thumbnail-image thumbnail-none"></span>
                     {{ end }}
                     </a>
                 </div>

--- a/layouts/partials/widgets/recent_articles.html
+++ b/layouts/partials/widgets/recent_articles.html
@@ -7,13 +7,15 @@
         <ul id="recent-post">
             {{ range first 5 (where .Site.Pages "Type" "post") }}
             <li>
-                {{ with .Params.banner }}
                 <div class="item-thumbnail">
                     <a href="{{ $.Permalink }}" class="thumbnail">
-                        <span style="background-image:url({{ $.Site.BaseURL }}{{ . }})" alt="{{ $.Title }}" class="thumbnail-image"></span>
+                    {{ if isset .Params "banner" }}
+                        <span style="background-image:url({{ $.Site.BaseURL }}{{ .Params.banner }})" alt="{{ $.Title }}" class="thumbnail-image"></span>
+                    {{else}}
+                        <span style="background-image:url({{ .Site.BaseURL }}css/images/thumb-default-small.png)" alt="{{ $.Title }}" class="thumbnail-image"></span>
+                    {{ end }}
                     </a>
                 </div>
-                {{ end }}
                 <div class="item-inner">
                     {{ if ge (len .Params.categories ) 1 }}
                     <p class="item-category">


### PR DESCRIPTION
Setting default thumbnail when no banner image is present for a recent article.
Default thumbnail image was present in the css/images folder but was not being used. 
This change updates the recent_articles.html widget partial code to use the default thumbnail image when no banner image is present in the post.
This would be useful for blogs which don't have banner (featured) image set for all posts.

Tested with 
Windows 10, Hugo v0.15

Regards,
Kanishk
