### PR TITLE
Fixing URL paths

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl = "www.yourdomain.com"
+baseurl = "http://www.yourdomain.com/"
 languageCode = "en-us"
 title = "Icarus"
 # Enable comments by entering your Disqus shortname

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,7 +12,7 @@
       <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
     <link rel="icon" href="{{ .Site.BaseURL }}favicon.ico">
-    <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}apple-touch-icon.png" />
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/font-awesome.min.css">
     <link rel="stylesheet" href="{{ .Site.BaseURL }}css/monokai.css">

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -6,7 +6,7 @@
         <ul class="category-list">
             {{ range $name, $items := .Site.Taxonomies.categories }}
             <li class="category-list-item">
-                <a class="category-list-link" href="{{ $.Site.BaseURL }}/categories/{{ $name }}">
+                <a class="category-list-link" href="{{ $.Site.BaseURL }}categories/{{ $name }}">
                     {{ $name }}
                 </a>
                 <span class="category-list-count">{{ len $items }}</span>


### PR DESCRIPTION
1. Fixing additional backslash in URL paths. Prior to this change, some of the URLs were being generated with additional backslash. e.g. http://localhost:1313//apple-touch-icon.png
2. Updating baseurl in exampleSite/config.toml to correct URL format expected by Hugo. Prior to this change, absence of http:// and and ending slash was resulting in invalid URLs at the live site.
