### PR TITLE
Fixes to allow spaces in Categories and Tags

### DIFF
--- a/exampleSite/content/post/go-is-for-lovers.md
+++ b/exampleSite/content/post/go-is-for-lovers.md
@@ -231,7 +231,7 @@ instead of depending on the context.
 
       {{ $title := .Site.Title }}
       {{ range .Params.tags }}
-        <li> <a href="{{ $baseurl }}/tags/{{ . | urlize }}">{{ . }}</a> - {{ $title }} </li>
+        <li> <a href="{{ $baseurl }}/tags/{{ . | urlize | lower  }}">{{ . }}</a> - {{ $title }} </li>
       {{ end }}
 
 Notice how once we have entered the loop the value of {{ . }} has changed. We

--- a/layouts/partials/article_header.html
+++ b/layouts/partials/article_header.html
@@ -18,7 +18,7 @@
         <div class="article-category">
             {{ range .Params.categories }}
             <i class="fa fa-folder"></i>
-            <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ . | lower }}">{{ . }}</a>
+            <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ . | urlize | lower }}">{{ . }}</a>
             {{ end }}
         </div>
     </div>

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -6,7 +6,7 @@
         <ul class="category-list">
             {{ range $name, $items := .Site.Taxonomies.categories }}
             <li class="category-list-item">
-                <a class="category-list-link" href="{{ $.Site.BaseURL }}categories/{{ $name }}">
+                <a class="category-list-link" href="{{ $.Site.BaseURL }}categories/{{ $name | urlize | lower }}">
                     {{ $name }}
                 </a>
                 <span class="category-list-count">{{ len $items }}</span>

--- a/layouts/partials/widgets/recent_articles.html
+++ b/layouts/partials/widgets/recent_articles.html
@@ -19,7 +19,7 @@
                 <div class="item-inner">
                     {{ if ge (len .Params.categories ) 1 }}
                     <p class="item-category">
-                        <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | lower }}">
+                        <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">
                         {{ index .Params.categories 0 }}
                         </a>
                     </p>

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -6,7 +6,7 @@
     </h3>
     <div class="widget tagcloud">
         {{ range $name, $items := .Site.Taxonomies.tags }}
-        <a href="{{ $.Site.BaseURL }}tags/{{ $name }}" style="font-size: 12px;">{{ $name }}</a>
+        <a href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower  }}" style="font-size: 12px;">{{ $name }}</a>
         {{ end }}
     </div>
 </div>

--- a/layouts/partials/widgets/tags.html
+++ b/layouts/partials/widgets/tags.html
@@ -8,7 +8,7 @@
         <ul class="category-list">
             {{ range $name, $items := .Site.Taxonomies.tags }}
             <li class="category-list-item">
-                <a class="category-list-link" href="{{ $.Site.BaseURL }}tags/{{ $name }}">
+                <a class="category-list-link" href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower }}">
                     {{ $name }}
                 </a>
                 <span class="category-list-count">{{ len $items }}</span>


### PR DESCRIPTION
I discovered a slight issue where Categories and Tags that contained spaces would not link properly.  adding "urlize" to the variable seems to have fixed the issue
