### PR TITLE
Article level meta tag for description

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,7 @@
 +++
 tags = []
 categories = []
+page_description = ""
 menu = ""
 banner = ""
 images = []

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
-    {{ with .Site.Params.site_description }}<meta name="description" content="{{ . }}">{{ end }}
+    {{ if .Params.page_description }}
+      <meta name="description" content="{{ .Params.page_description }}">
+    {{ else if .Site.Params.site_description }}
+      <meta name="description" content="{{ .Site.Params.site_description }}">
+    {{ end }}
     {{ if .RSSlink }}
       <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
       <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />


### PR DESCRIPTION
For better SEO, I added the meta tag for description for every article in my blog. If it will be useful for large audience you can merge it into your repo. 

I have very limited knowledge on hugo. May not be the best way to solve it. Let me know if there is a better way. I will make changes accordingly.
