### PR TITLE
Clean up front matter in example content

### DIFF
--- a/exampleSite/content/post/creating-a-new-theme.md
+++ b/exampleSite/content/post/creating-a-new-theme.md
@@ -1,10 +1,10 @@
 +++
-banner = "banners/placeholder.png"
-categories = ["Lorem"]
-date = "2015-06-24T13:50:46+02:00"
-menu = ""
-tags = []
 title = "Creating a new theme"
+date = "2015-06-24T13:50:46+02:00"
+tags = ["theme"]
+categories = ["starting"]
+menu = ""
+banner = "banners/placeholder.png"
 +++
 
 ## Introduction

--- a/exampleSite/content/post/go-is-for-lovers.md
+++ b/exampleSite/content/post/go-is-for-lovers.md
@@ -1,10 +1,10 @@
 +++
-banner = "banners/placeholder.png"
-categories = ["Ipsum"]
-date = "2015-09-17T13:47:08+02:00"
-menu = ""
-tags = []
 title = "Go is for lovers"
+date = "2015-09-17T13:47:08+02:00"
+tags = ["go"]
+categories = ["programming"]
+menu = ""
+banner = "banners/placeholder.png"
 +++
 
 Hugo uses the excellent [go][] [html/template][gohtmltemplate] library for

--- a/exampleSite/content/post/hugo-is-for-lovers.md
+++ b/exampleSite/content/post/hugo-is-for-lovers.md
@@ -1,10 +1,10 @@
 +++
-banner = "banners/placeholder.png"
-categories = ["Lorem"]
-date = "2015-08-03T13:39:46+02:00"
-menu = ""
-tags = []
 title = "Hugo is for lovers"
+date = "2015-08-03T13:39:46+02:00"
+tags = ["hugo"]
+categories = ["pseudo"]
+menu = ""
+banner = "banners/placeholder.png"
 +++
 
 ## Step 1. Install Hugo

--- a/exampleSite/content/post/introducing-icarus-and-its-features.md
+++ b/exampleSite/content/post/introducing-icarus-and-its-features.md
@@ -1,10 +1,11 @@
 +++
-date = "2015-10-10T16:56:43+02:00"
 title = "Introducing Icarus and it's features"
+date = "2015-10-10T16:56:43+02:00"
 tags = ["theme", "hugo", "static sites"]
+categories = ["theme"]
+menu = ""
 images = []
 banner = "banners/placeholder.png"
-categories = ["Lorem"]
 +++
 
 Icarus is a responsive and customizable theme for bloggers. It's a port of the same-named theme for [Hexo](//hexo.io) made by [Ruipeng Zhang](https://github.com/ppoffice). Noteworthy features of this Hugo theme are the integration of a comment-system powered by Disqus, localization (l10n) support, syntax highlighting for source code, optional widgets for the sidebar and a handful [shortcodes](http://gohugo.io/extras/shortcodes/) to make your life easier.

--- a/exampleSite/content/post/linked-post.md
+++ b/exampleSite/content/post/linked-post.md
@@ -1,9 +1,9 @@
 +++
-date = "2015-10-02T21:49:20+02:00"
 title = "Linked post"
-menu = "main"
+date = "2015-10-02T21:49:20+02:00"
 tags = ["golang", "programming", "theme", "hugo"]
 categories = ["programming"]
+menu = "main"
 banner = "banners/placeholder.png"
 +++
 

--- a/exampleSite/content/post/migrate-from-jekyll.md
+++ b/exampleSite/content/post/migrate-from-jekyll.md
@@ -1,8 +1,8 @@
 +++
 title = "Migrate from Jekyll"
 date = "2015-10-10T13:07:31+02:00"
-tags = []
-categories = ["Lorem"]
+tags = ["ipsum"]
+categories = ["lorem"]
 menu = ""
 banner = "banners/placeholder.png"
 +++


### PR DESCRIPTION
When tags or categories are missing on any post of content on a site using this theme, this error happens: 

```
ERROR: 2015/12/23 reflect: call of reflect.Value.Type on zero Value in theme/partials/article_header.html
```

Ideally, the theme wouldn't cause this error. But, I solved this by making sure my sample content all had categories and tags. I also organized the front matter.
