### PR TITLE
Fix typos and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ I assume you've Git installed. Inside the folder of your Hugo site run
     $ cd themes
     $ git clone https://github.com/digitalcraftsman/hugo-icarus-theme.git
 
-You should see a folder called `hugo-icarus-theme` inside the `themes` directory, that we created a few moments ago. For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
+You should see a folder called `hugo-icarus-theme` inside the `themes` directory that we created a few moments ago. For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
 
 
 ## Setup
 
-In the next step navigate to the `exampleSite` folder at `themes/hugo-icarus-theme/exampleSite/`. It's structure shoud look similar to this:
+In the next step navigate to the `exampleSite` folder at `themes/hugo-icarus-theme/exampleSite/`. Its structure should look similar to this:
 
     exampleSite
     ├── config.toml
@@ -65,10 +65,10 @@ Furthermore, we can add entries that don't link to posts. Back in the `config.to
         label  = "Home"
         link   = "/"
 
-Define a label and enter the URL to resource you want to link. With `before` you can decide wether the link should appear before **or** after all linked posts in the menu. Therefore, `Home` appears before the linked post.
+Define a label and enter the URL to resource you want to link. With `before` you can decide whether the link should appear before **or** after all linked posts in the menu. Therefore, `Home` appears before the linked post.
 
 
-### Tell me who you're
+### Tell me who you are
 
 This theme also provides a profile section on the left. Add your social network accounts to the profile section on the left by entering your username under `social`. The links to your account will be create automatically.
 
@@ -93,7 +93,7 @@ You can deactivate them under `params.widgets`:
 
 ## Localization (l10n)
 
-You don't blog in english and you want to translate the theme into your native locale? No problem. Take a look in the `data` folder and you'll find a file `l10n.toml` that we've copied at the beginning. It contains all strings related to the theme. Just replace the original strings with your own.
+You don't blog in English and you want to translate the theme into your native locale? No problem. Take a look in the `data` folder and you'll find a file `l10n.toml` that we've copied at the beginning. It contains all strings related to the theme. Just replace the original strings with your own.
 
 
 ## Linking thumbnails
@@ -107,12 +107,12 @@ This way you can store them either next to the content file or in the `static` f
 
 ## Mathematical equations
 
-In case you need to display equations you can insert your Latex or MathML code and it works out of the box thanks to [MathJax](https://www.mathjax.org).
+In case you need to display equations you can insert your LaTeX or MathML code and it works out of the box thanks to [MathJax](https://www.mathjax.org).
 
 
 ## Shortcodes
 
-Last but not least I included some useful [shortcodes](http://gohugo.io/extras/shortcodes/) to make your like easier.
+Last but not least I included some useful [shortcodes](http://gohugo.io/extras/shortcodes/) to make your life easier.
 
 
 ### Gallery
@@ -125,7 +125,7 @@ This way you can include a gallery into your post. Copy the code below into your
         "/banners/placeholder.png"
     >}}
 
-### JSFidde
+### JSFiddle
 
 It works the same with JSFiddle examples you want to showcase. The parameter `id` consists of the username and id of the example.
 
@@ -141,12 +141,12 @@ In order to see your site in action, run Hugo's built-in local server.
 
     $ hugo server
 
-Now enter [`localhost:1313`](//localhost:1313) in the address bar of your browser.
+Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your browser.
 
 
 ## Contributing
 
-Did you found a bug or got an idea for a new feature? Feel free to use the [issue tracker](//github.com/digitalcraftsman/hugo-icarus-theme/issues) to let me know. Or make directly a [pull request](//github.com/digitalcraftsman/hugo-icarus-theme/pulls).
+Have you found a bug or got an idea for a new feature? Feel free to use the [issue tracker](//github.com/digitalcraftsman/hugo-icarus-theme/issues) to let me know. Or make directly a [pull request](//github.com/digitalcraftsman/hugo-icarus-theme/pulls).
 
 
 ## License
@@ -154,6 +154,6 @@ Did you found a bug or got an idea for a new feature? Feel free to use the [issu
 This theme is released under the MIT license. For more information read the [license](https://github.com/digitalcraftsman/hugo-icarus-theme/blob/master/LICENSE.md).
 
 
-## Annotations
+## Acknowledgement
 
 Thanks to [Steve Francia](//github.com/spf13) for creating Hugo and the awesome community around the project.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,18 +16,18 @@ theme = "hugo-icarus-theme"
 
 
 [params]
-    # Tell me who you're
+    # Tell me who you are
     author = "John Doe"
     bio = "Blogger - Programmer - Gopher"
     location = "Earth"
     site_description = ""
     copyright  = "Powered by [Hugo](//gohugo.io). Theme by [PPOffice](http://github.com/ppoffice)."
 
-    # Format dates with Go's time formating
+    # Format dates with Go's time formatting
     date_format = "2006-01-02"
 
 # Create custom menu entries by defining a label and a link for
-# them. Since you can also link posts you've the option the
+# them. Since you can also link posts, you've the option the
 # place the links before or after them.
 #
 # E.g.: "Home" appears before all linked posts in the menu

--- a/exampleSite/content/post/introducing-icarus-and-its-features.md
+++ b/exampleSite/content/post/introducing-icarus-and-its-features.md
@@ -1,5 +1,5 @@
 +++
-title = "Introducing Icarus and it's features"
+title = "Introducing Icarus and its features"
 date = "2015-10-10T16:56:43+02:00"
 tags = ["theme", "hugo", "static sites"]
 categories = ["theme"]
@@ -19,12 +19,12 @@ I assume you've Git installed. Inside the folder of your Hugo site run
     $ cd themes
     $ git clone git@github.com:digitalcraftsman/hugo-icarus-theme.git
 
-You should see a folder called `hugo-icarus-theme` inside the `themes` directory, that we created a few moments ago. For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
+You should see a folder called `hugo-icarus-theme` inside the `themes` directory that we created a few moments ago. For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
 
 
 ## Setup
 
-In the next step navigate to the `exampleSite` folder at `themes/hugo-icarus-theme/exampleSite/`. It's structure shoud look similar to this:
+In the next step navigate to the `exampleSite` folder at `themes/hugo-icarus-theme/exampleSite/`. Its structure should look similar to this:
 
     exampleSite
     ├── config.toml
@@ -72,10 +72,10 @@ Furthermore, we can add entries that don't link to posts. Back in the `config.to
         label  = "Home"
         link   = "/"
 
-Define a label and enter the URL to resource you want to link. With `before` you can decide wether the link should appear before **or** after all linked posts in the menu. `Home` appears before the linked post, `Tags` and `Categories` after them (as in the menu above).
+Define a label and enter the URL to resource you want to link. With `before` you can decide whether the link should appear before **or** after all linked posts in the menu. `Home` appears before the linked post, `Tags` and `Categories` after them (as in the menu above).
 
 
-### Tell me who you're
+### Tell me who you are
 
 Maybe you noticed the profile section on the left. Add your social network accounts to the profile section on the left by entering your username under `social`. The links to your account will be create automatically.
 
@@ -93,7 +93,7 @@ On the right, you can see some useful widgets that you can activate as you like.
 
 ## Localization (l10n)
 
-You don't blog in english and you want to translate the theme into your native locale? No problem. Take a look in the `data` folder and you'll find a file `l10n.toml` that we've copied at the beginning. It contains all strings related to the theme. Just replace the original strings with your own.
+You don't blog in English and you want to translate the theme into your native locale? No problem. Take a look in the `data` folder and you'll find a file `l10n.toml` that we've copied at the beginning. It contains all strings related to the theme. Just replace the original strings with your own.
 
 
 ## Linking thumbnails
@@ -107,7 +107,7 @@ This way you can store them either next to the content file or in the `static` f
 
 ## Mathematical equations
 
-In case you need to display equations you can insert your Latex or MathML code and it works out of the box thanks to [MathJax](https://www.mathjax.org).
+In case you need to display equations you can insert your LaTeX or MathML code and it works out of the box thanks to [MathJax](https://www.mathjax.org).
 
     \[ z = r \cdot (\sin{\phi} + \cos{\phi} \cdot i) \]
 
@@ -116,7 +116,7 @@ In case you need to display equations you can insert your Latex or MathML code a
 
 ## Shortcodes
 
-Last but not least I included some useful [shortcodes](http://gohugo.io/extras/shortcodes/) to make your like easier.
+Last but not least I included some useful [shortcodes](http://gohugo.io/extras/shortcodes/) to make your life easier.
 
 ### Gallery
 
@@ -133,7 +133,7 @@ This way you can include a gallery into your post. Copy the code below into your
 {{< gallery "/banners/placeholder.png" "/banners/placeholder.png" "/banners/placeholder.png" >}}
 
 
-### JSFidde
+### JSFiddle
 
 It works the same with JSFiddle examples you want to showcase. The parameter `id` consists of the username and id of the example.
 
@@ -158,12 +158,12 @@ In order to see your site in action, run Hugo's built-in local server.
 
     $ hugo server
 
-Now enter [`localhost:1313`](//localhost:1313) in the address bar of your browser.
+Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your browser.
 
 
 ## Contributing
 
-Did you found a bug or got an idea for a new feature? Feel free to use the [issue tracker](//github.com/digitalcraftsman/hugo-icarus-theme/issues) to let me know. Or make directly a [pull request](//github.com/digitalcraftsman/hugo-icarus-theme/pulls).
+Have you found a bug or got an idea for a new feature? Feel free to use the [issue tracker](//github.com/digitalcraftsman/hugo-icarus-theme/issues) to let me know. Or make directly a [pull request](//github.com/digitalcraftsman/hugo-icarus-theme/pulls).
 
 
 ## License

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,5 +1,5 @@
 {{ with .Site.Social.github }}
-<td><a href="//github.com/{{.}}" target="_blank" title="Github"><i class="fa fa-github"></i></a></td>
+<td><a href="//github.com/{{.}}" target="_blank" title="GitHub"><i class="fa fa-github"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.bitbucket }}
@@ -11,7 +11,7 @@
 {{ end }}
 
 {{ with .Site.Social.codepen }}
-<td><a href="//codepen.io/{{.}}" target="_blank" title="Codepen"><i class="fa fa-codepen"></i></a></td>
+<td><a href="//codepen.io/{{.}}" target="_blank" title="CodePen"><i class="fa fa-codepen"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.foursquare }}
@@ -23,7 +23,7 @@
 {{ end }}
 
 {{ with .Site.Social.deviantart }}
-<td><a href="//{{.}}.deviantart.com/" target="_blank" title="Deviantart"><i class="fa fa-deviantart"></i></a></td>
+<td><a href="//{{.}}.deviantart.com/" target="_blank" title="DeviantArt"><i class="fa fa-deviantart"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.behance }}
@@ -39,7 +39,7 @@
 {{ end }}
 
 {{ with .Site.Social.youtube }}
-<td><a href="//youtube.com/{{.}}" target="_blank" title="Youtube"><i class="fa fa-youtube"></i></a></td>
+<td><a href="//youtube.com/{{.}}" target="_blank" title="YouTube"><i class="fa fa-youtube"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.vimeo }}
@@ -55,7 +55,7 @@
 {{ end }}
 
 {{ with .Site.Social.wordpress }}
-<td><a href="//{{.}}.wordpress.com" target="_blank" title="Wordpress"><i class="fa fa-wordpress"></i></a></td>
+<td><a href="//{{.}}.wordpress.com" target="_blank" title="WordPress"><i class="fa fa-wordpress"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.tumblr }}
@@ -67,15 +67,15 @@
 {{ end }}
 
 {{ with .Site.Social.linkedin }}
-<td><a href="//linkedin.com/in/{{.}}" target="_blank" title="Linkedin"><i class="fa fa-linkedin"></i></a></td>
+<td><a href="//linkedin.com/in/{{.}}" target="_blank" title="LinkedIn"><i class="fa fa-linkedin"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.slideshare }}
-<td><a href="//slideshare.com/{{.}}" target="_blank" title="Slideshare"><i class="fa fa-slideshare"></i></a></td>
+<td><a href="//slideshare.com/{{.}}" target="_blank" title="SlideShare"><i class="fa fa-slideshare"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.stackoverflow }}
-<td><a href="//stackoverflow.com/users/{{.}}" target="_blank" title="Stackoverflow"><i class="fa fa-stackoverflow"></i></a></td>
+<td><a href="//stackoverflow.com/users/{{.}}" target="_blank" title="Stack Overflow"><i class="fa fa-stackoverflow"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.reddit }}

--- a/theme.toml
+++ b/theme.toml
@@ -14,5 +14,5 @@ min_version = 0.15
 # If porting an existing theme
 [original]
   name = "Ruipeng Zhang"
-  homepage = "//blog.zhangruipeng.me"
+  homepage = "http://blog.zhangruipeng.me"
   repo = "//github.com/ppoffice/hexo-theme-icarus"


### PR DESCRIPTION
Thank you very much for bringing Icarus theme to Hugo!

Besides minor typo fixes, I also added the `http:` prefix as the scheme for the URLs that absolutely need it, especially http://localhost:1313 (`hugo server` does not yet support HTTPS) and http://blog.zhangruipeng.me/ (his server does not support HTTPS).

Thanks!
