### PR TITLE
Support hotlinked gravatar in addtion to avatar

### DIFF
--- a/layouts/partials/profile.html
+++ b/layouts/partials/profile.html
@@ -1,7 +1,9 @@
 <aside id="profile">
   <div class="inner profile-inner">
     <div class="base-info profile-block">
-      <img id="avatar" src="{{ .Site.BaseURL }}{{ .Site.Params.avatar }}">
+      {{ if .Site.Params.avatar}}<img id="avatar" src="{{ .Site.BaseURL }}{{ .Site.Params.avatar }}">
+      {{ else if .Site.Params.gravatar}}<img id="avatar" src="{{ .Site.Params.gravatar }}">
+      {{ end }}
       {{ with .Site.Params.author}}<h2 id="name">{{ . }}</h2>{{ end }}
       {{ with .Site.Params.bio }}<h3 id="title">{{ . }}</h3>{{ end }}
       {{ with .Site.Params.location }}<span id="location"><i class="fa fa-map-marker"></i>{{ . }}</span>{{ end }}


### PR DESCRIPTION
This change adds a "gravatar" param which takes a URL to a gravatar (or other hot-linkable image) in lieu of "avatar."  Default to "avatar" if it exists, before checking "gravatar" param.

No need to pull this change if you don't want it, but I'm going to use it locally, and thought I'd share if you think it's a good idea.
