### PR TITLE
Fix support for external avatar in nav profile image as well

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,7 +21,7 @@
       </nav>
         <nav id="sub-nav">
           <div class="profile" id="profile-nav">
-            <a id="profile-anchor" href="javascript:;"><img class="avatar" src="{{ .Site.BaseURL }}{{ .Site.Params.avatar }}"><i class="fa fa-caret-down"></i></a>
+            <a id="profile-anchor" href="javascript:;"><img class="avatar" src="{{ .Site.Params.avatar | absURL }}"><i class="fa fa-caret-down"></i></a>
           </div>
         </nav>
         <div id="search-form-wrap">


### PR DESCRIPTION
The change at 06542c91da5356bfad0529303984b691528c1642 causes the profile image in mobile mode to have a broken link.  This fixes it there as well.
