### PR TITLE
Add trailing slash to example base URL

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://example.org"
+baseurl = "https://example.org/"
 languageCode = "en-us"
 title = "Icarus"
 # Enable comments by entering your Disqus shortname


### PR DESCRIPTION
Lack of trailing slash leads to urls of the type `https://example.orgcss/font-awesome.min.css` rather than `https://example.org/css/font-awesome.min.css`. It's a Hugo issue.
