### PR TITLE
Paginator adds an extra '/' to the URL which messes up AWS S3.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://example.org/"
+baseurl = "https://example.org"
 languageCode = "en-us"
 title = "Icarus"
 # Enable comments by entering your Disqus shortname

--- a/layouts/partials/article_header.html
+++ b/layouts/partials/article_header.html
@@ -23,7 +23,7 @@
             <div class="article-category">
                 <i class="fa fa-folder"></i>
                 {{ range $k, $v := .Params.categories }}
-                <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ . | urlize | lower }}">{{ . }}</a>
+                <a class="article-category-link" href="{{ $.Site.BaseURL }}/categories/{{ . | urlize | lower }}">{{ . }}</a>
                 {{ if lt $k (sub $categoriesLen 1) }}&middot;{{ end }}
                 {{ end }}
             </div>
@@ -36,7 +36,7 @@
             <div class="article-category">
                 <i class="fa fa-tags"></i>
                 {{ range $k, $v := .Params.tags }}
-                <a class="article-category-link" href="{{ $.Site.BaseURL }}tags/{{ . | urlize | lower }}">{{ . }}</a>
+                <a class="article-category-link" href="{{ $.Site.BaseURL }}/tags/{{ . | urlize | lower }}">{{ . }}</a>
                 {{ if lt $k (sub $tagsLen 1) }}&middot;{{ end }}
                 {{ end }}
             </div>

--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -1,6 +1,6 @@
 {{ template "_internal/google_analytics.html" . }}
-<script src="{{ .Site.BaseURL }}fancybox/jquery.fancybox.pack.js"></script>
-<script src="{{ .Site.BaseURL }}js/script.js"></script>
+<script src="{{ .Site.BaseURL }}/fancybox/jquery.fancybox.pack.js"></script>
+<script src="{{ .Site.BaseURL }}/js/script.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/highlight.min.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{ range .Site.Params.custom_js }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,12 +16,12 @@
       <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
     <link rel="canonical" href="{{ .Permalink }}"/>
-    <link rel="icon" href="{{ .Site.BaseURL }}favicon.ico">
-    <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}apple-touch-icon.png" />
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/font-awesome.min.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/monokai.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}fancybox/jquery.fancybox.css">
+    <link rel="icon" href="{{ .Site.BaseURL }}/favicon.ico">
+    <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}/apple-touch-icon.png" />
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/font-awesome.min.css">
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/monokai.css">
+    <link rel="stylesheet" href="{{ .Site.BaseURL }}/fancybox/jquery.fancybox.css">
     {{ range .Site.Params.custom_css }}
     <link rel="stylesheet" href="{{ . | absURL }}">
     {{ end }}

--- a/layouts/partials/widgets/categories.html
+++ b/layouts/partials/widgets/categories.html
@@ -7,7 +7,7 @@
         <ul class="category-list">
             {{ range $name, $items := .Site.Taxonomies.categories }}
             <li class="category-list-item">
-                <a class="category-list-link" href="{{ $.Site.BaseURL }}categories/{{ $name | urlize | lower }}">
+                <a class="category-list-link" href="{{ $.Site.BaseURL }}/categories/{{ $name | urlize | lower }}">
                     {{ $name }}
                 </a>
                 <span class="category-list-count">{{ len $items }}</span>

--- a/layouts/partials/widgets/recent_articles.html
+++ b/layouts/partials/widgets/recent_articles.html
@@ -20,7 +20,7 @@
                     {{ if isset .Params "categories" }}
                     {{ if gt (len .Params.categories) 0 }}
                     <p class="item-category">
-                        <a class="article-category-link" href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">
+                        <a class="article-category-link" href="{{ $.Site.BaseURL }}/categories/{{ index .Params.categories 0 | urlize | lower }}">
                         {{ index .Params.categories 0 }}
                         </a>
                     </p>

--- a/layouts/partials/widgets/tag_cloud.html
+++ b/layouts/partials/widgets/tag_cloud.html
@@ -7,7 +7,7 @@
     </h3>
     <div class="widget tagcloud">
         {{ range $name, $items := .Site.Taxonomies.tags }}
-        <a href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower  }}" style="font-size: 12px;">{{ $name }}</a>
+        <a href="{{ $.Site.BaseURL }}/tags/{{ $name | urlize | lower  }}" style="font-size: 12px;">{{ $name }}</a>
         {{ end }}
     </div>
 </div>

--- a/layouts/partials/widgets/tags.html
+++ b/layouts/partials/widgets/tags.html
@@ -9,7 +9,7 @@
         <ul class="category-list">
             {{ range $name, $items := .Site.Taxonomies.tags }}
             <li class="category-list-item">
-                <a class="category-list-link" href="{{ $.Site.BaseURL }}tags/{{ $name | urlize | lower }}">
+                <a class="category-list-link" href="{{ $.Site.BaseURL }}/tags/{{ $name | urlize | lower }}">
                     {{ $name }}
                 </a>
                 <span class="category-list-count">{{ len $items }}</span>


### PR DESCRIPTION
I fixed my problem and created a pull request which you may want to take a look at. I couldn't find a way to strip off the extra '/' from the pre/next link so I removed the trailing slash from the baseURL and updated the source to take account. I don't know if this is the best way of doing this, but it does fix my problem. Would welcome any feedback or a better way.

Thanks for a very nice theme.

Patrick