### PR TITLE
Fix tags and categories links when reading a post

### DIFF
--- a/layouts/partials/article_header.html
+++ b/layouts/partials/article_header.html
@@ -23,7 +23,7 @@
             <div class="article-category">
                 <i class="fa fa-folder"></i>
                 {{ range $k, $v := .Params.categories }}
-                {{ $url := printf "%s/%s" "categories" (. | urlize | lower) }}
+                {{ $url := printf "/categories/%s" (. | urlize | lower) | absURL }}
                 <a class="article-category-link" href="{{ $url }}">{{ . }}</a>
                 {{ if lt $k (sub $categoriesLen 1) }}&middot;{{ end }}
                 {{ end }}
@@ -37,7 +37,7 @@
             <div class="article-category">
                 <i class="fa fa-tags"></i>
                 {{ range $k, $v := .Params.tags }}
-                {{ $url := printf "%s/%s" "tags" (. | urlize | lower) }}
+                {{ $url := printf "/tags/%s" (. | urlize | lower) | absURL }}
                 <a class="article-category-link" href="{{ $url }}">{{ . }}</a>
                 {{ if lt $k (sub $tagsLen 1) }}&middot;{{ end }}
                 {{ end }}


### PR DESCRIPTION
Tags and categories links in article header were relative to current page,
which works well when people are on the homepage.
However, when you are in a blog post (/post/<…>), then, it's appended to it and
ends up as /post/<…>/tags/foo for instance, leading to a 404.
Add a / in front of links to be always relative to the root of the website.

Note that this won't work in case there is a baseurl being a subdirectory.
We can thus prepend baseurl in the string link if this is the general theme
approach.