### PR TITLE
Run custom JS before starting highlight.js

### DIFF
--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -2,10 +2,11 @@
 <script src="{{ "fancybox/jquery.fancybox.pack.js" | absURL }}"></script>
 <script src="{{ "js/script.js" | absURL }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+
 {{ range .Site.Params.custom_js }}
 <script src="{{ . | absURL }}"></script>
 {{ end }}
+<script>hljs.initHighlightingOnLoad();</script>
 
 {{ "<!-- MathJax -->" | safeHTML }}
 <script type="text/x-mathjax-config">


### PR DESCRIPTION
highlight.js is configurable, and guaranteeing that your code runs before hljs gets started is nice I think.
Although the highlighting is likely to run after the custom JavaScript anyway, because `initHighlightingOnLoad` just sets up event listeners, so I don't know if it will ever be a real problem.