### PR TITLE
Hiding the comments link in a post if Disqus is not configured or comments are disabled

### DIFF
--- a/layouts/partials/article_footer.html
+++ b/layouts/partials/article_footer.html
@@ -3,7 +3,7 @@
         <i class="fa fa-share"></i>
         {{with .Site.Data.l10n.articles.share}}{{.}}{{end}}
     </a>
-    {{ if not (eq .Site.DisqusShortname "") }}
+    {{ if and (not (eq .Site.DisqusShortname "")) (not .Params.disable_comments) }}
     <a href="{{ .Permalink }}/#disqus_thread" class="article-comment-link">
         {{with .Site.Data.l10n.articles.comments}}{{.}}{{end}}
     </a>


### PR DESCRIPTION
Hiding the comments link if Disqus is not configured or comments are disabled.