### PR TITLE
Fix: comments not loaded if article is accessed by comments-link

### DIFF
--- a/layouts/partials/article_footer.html
+++ b/layouts/partials/article_footer.html
@@ -4,7 +4,7 @@
         {{with .Site.Data.l10n.articles.share}}{{.}}{{end}}
     </a>
     {{ if not (eq .Site.DisqusShortname "") }}
-    <a href="{{ .Permalink }}/#disqus_thread" class="article-comment-link">
+    <a href="{{ .Permalink }}#disqus_thread" class="article-comment-link">
         {{with .Site.Data.l10n.articles.comments}}{{.}}{{end}}
     </a>
     {{end}}


### PR DESCRIPTION
Original code results in `...//#disqus_thread` instead of  `.../#disqus_thread` which prevents comments from being loaded.