### PR TITLE
Option to disable MathJax but enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Mathematical equations in form of LaTeX or MathML code can be rendered with the 
 
 You can also print formulas inline. In this case wrap the formula only once with `$`.
 
-If you don't need equations, you can disable MathJax but putting `mathjax = false` in your config.toml. This will prevent clients from unnecessarily downloading the MathJax library.
+If you don't need equations, you can disable MathJax but putting `disable_mathjax = true` in your config.toml. This will prevent clients from unnecessarily downloading the MathJax library.
 
 ## Shortcodes
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -24,7 +24,7 @@ theme = "hugo-icarus-theme"
     copyright  = "Powered by [Hugo](//gohugo.io). Theme by [PPOffice](http://github.com/ppoffice)."
     avatar = "css/images/avatar.png"
     logo = "css/images/logo.png"
-    mathjax = true # set to false to disable MathJax
+    disable_mathjax = false # set to true to disable MathJax
 
     # Format dates with Go's time formatting
     date_format = "2006-01-02"

--- a/layouts/partials/footer_js.html
+++ b/layouts/partials/footer_js.html
@@ -8,7 +8,7 @@
 {{ end }}
 <script>hljs.initHighlightingOnLoad();</script>
 
-{{ if .Site.Params.mathjax }}
+{{ if not .Site.Params.disable_mathjax }}
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
   tex2jax: {


### PR DESCRIPTION
Fixes previous commit which allowed disabling MathJax, but would have disabled MathJax if the site parameter mathjax was not included. This would have broken existing sites that don't have that parameter in their config.toml. Now MathJax is controlled by the disable_mathjax site parameter. If it does not exist, MathJax will be enabled, so nothing is broken...yay!