### PR TITLE
Enable suppression of prev/next links

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ You can deactivate them under `params.widgets`:
 
 The date line includes: post date, # of words, approximate reading, time tags and categories. However, if you want certain pages to omit the date line, simply put `nodateline = true` in the front matter for that page.
 
+### Disable Previous / next article links
+
+To disable the inclusion of a previous/next article link at the bottom of the page, add `noprevnext = true` to the front matter. This feature, along with `nodateline` can be used to create standalone pages that are less "blog-like"
+
 ## Localization (l10n)
 
 You don't blog in English and you want to translate the theme into your native locale? No problem. Take a look in the `data` folder and you'll find a file `l10n.toml` that we've copied at the beginning. It contains all strings related to the theme. Just replace the original strings with your own.

--- a/layouts/partials/prev_next_post.html
+++ b/layouts/partials/prev_next_post.html
@@ -1,4 +1,4 @@
-{{ if or .PrevInSection .NextInSection }}
+{{ if and (or .PrevInSection .NextInSection) (not .Params.noprevnext) }}
 <nav id="article-nav">
     {{ if .PrevInSection }}
     <a href="{{ .PrevInSection.Permalink }}" id="article-nav-older" class="article-nav-link-wrap">


### PR DESCRIPTION
This is another feature to help create standalone pages that are less blog-like by omitting the previous/next article links at the bottom of the page. To omit the link include `noprevnext = true` in frontmatter.

If this parameter is not present, the behavior will be as before; this modification is backwards compatible.  