### PR TITLE
fix to use new 0.18.0 RegularPages variable

### DIFF
--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -1,5 +1,5 @@
 <section id="main">
-    {{ $paginator := .Paginate (where .Site.Pages "Type" "post") }}
+    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "post") }}
     {{ range $paginator.Pages }}
     <article class="article article-type-post" itemscope="" itemprop="blogPost">
         <div class="article-inner">


### PR DESCRIPTION
The theme generated an extra item in the list for every directory in the content because everything is a Page since 0.18.0. Suggested update is to use .Site.RegularPages instead of .Site.Pages to loop over so the theme keeps working in the same way as it did before 0.18.0.

See details https://github.com/spf13/hugo/blob/afb3334ed8972a845c4f46cf225d6783bfc12e3f/docs/content/meta/release-notes.md#0180-december-19th-2016