### PR TITLE
Add slideshare shortcode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ As descibed in the [docs of JSFiddle](http://doc.jsfiddle.net/use/embedding.html
 
     {{< jsfiddle id="zalun/NmudS" tabs="html,result" >}}
 
+### SlideShare
+
+Embed SlideShare slides by passing its `id`. For example, if the slides' URL is `https://www.slideshare.net/<username>/<title-slug>-12345678`, then the shortcode looks like this:
+
+    {{< slideshare id="12345678" >}}
+
 ## Nearly finished
 
 In order to see your site in action, run Hugo's built-in local server.
@@ -184,7 +190,7 @@ This theme is released under the MIT license. For more information read the [lic
 
 ## Acknowledgements
 
-Thanks to 
+Thanks to
 
 - [Ruipeng Zhang](https://github.com/ppoffice) for creating this theme
 - [Steve Francia](//github.com/spf13) for creating Hugo and the awesome community around the project

--- a/layouts/shortcodes/slideshare.html
+++ b/layouts/shortcodes/slideshare.html
@@ -1,0 +1,4 @@
+<iframe
+  style="width: 100%; height: 500px;" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"
+  src="http://www.slideshare.net/slideshow/embed_code/{{.Get "id"}}?rel=0" allowfullscreen webkitallowfullscreen mozallowfullscreen> </iframe>
+<br><br>


### PR DESCRIPTION
Following jsfiddle shortcode using named parameters, SlideShare ID is passed via `id` attribute.