### PR TITLE
Changed Rendering for Mobile

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -51,16 +51,19 @@ themesDir = "../.."
     before = true
     label  = "Home"
     link   = "/"
+    icon   = "home"
 
 [[params.menu]]
     before = false
     label  = "Tags"
     link   = "tags/"
+    icon   = "tags"
 
 [[params.menu]]
     before = false
     label  = "Categories"
     link   = "categories/"
+    icon   = "list-ul"
 
 # Enter a link for the follow button on the left
 [params.profile]

--- a/exampleSite/content/about/_index.md
+++ b/exampleSite/content/about/_index.md
@@ -1,8 +1,12 @@
 +++
 title = "About"
 date = "2017-05-19T21:49:20+02:00"
-menu = "main"
 disable_comments = true
+post = "info"
+[menu.main]
+	icon = "info"
+	pre = "<i class='fa fa-info'></i>"
+
 +++
 
 Add some information about yourself.

--- a/exampleSite/content/post/linked-post.md
+++ b/exampleSite/content/post/linked-post.md
@@ -3,8 +3,10 @@ title = "How to add pages to the menu"
 date = "2015-10-02T21:49:20+02:00"
 tags = ["golang", "programming", "theme", "hugo"]
 categories = ["programming"]
-menu = "main"
 banner = "banners/placeholder.png"
+[menu.main]
+	icon = "info"
+	pre = "<i class='fa fa-question'></i>"
 +++
 
 I'm a linked post in the menu. You can add other posts by adding the following line to the frontmatter:

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,17 +10,29 @@
       <nav id="main-nav">
           {{ range .Site.Params.menu }}
           {{ if .before }}
+	  {{ if .icon }}
+	  <a class="main-nav-link" href="{{ .link | absURL }}"><i class="fa fa-{{ .icon }}"></i> {{ .label }}</a>
+	  {{ else }}
           <a class="main-nav-link" href="{{ .link | absURL }}">{{ .label }}</a>
+	  {{ end }}
           {{ end }}
           {{ end }}
 
           {{ range .Site.Menus.main }}
-          <a class="main-nav-link" href="{{ .URL }}">{{ .Name }}</a>
+	  {{ if .Pre }}
+          <a class="main-nav-link" href="{{ .URL }}"> {{.Pre}} {{ .Name }}</a>
+	  {{ else }}
+	  <a class="main-nav-link" href="{{ .URL }}">{{ .Name }}</a>
+	  {{ end }}
           {{ end }}
 
           {{ range .Site.Params.menu }}
           {{ if not .before }}
+	  {{ if .icon }}
+	  <a class="main-nav-link" href="{{ .link | absURL }}"><i class="fa fa-{{ .icon }}"></i> {{ .label }}</a>
+	  {{ else }}
           <a class="main-nav-link" href="{{ .link | absURL }}">{{ .label }}</a>
+	  {{ end }}
           {{ end }}
           {{ end }}
       </nav>
@@ -45,17 +57,35 @@
           <tr>
           {{ range .Site.Params.menu }}
           {{ if .before }}
-          <td><a class="main-nav-link" href="{{ .link | absURL }}">{{ .label }}</a></td>
+	  {{ if .icon }}
+	  <a class="main-nav-link" href="{{ .link | absURL }}" title ="{{ .label }}">
+	    <i class="fa fa-{{ .icon }}"></i>
+	  </a>
+	  {{ else }}
+          <td><a class="main-nav-link" href="{{ .link  | absURL }}">{{ .label }}</a></td>
+	  {{ end }}
+
           {{ end }}
           {{ end }}
 
           {{ range .Site.Menus.main }}
-          <td><a class="main-nav-link" href="{{ .URL }}">{{ .Name }}</a></td>
+
+	  {{ if .Pre }}
+          <a class="main-nav-link" href="{{ .URL }}"> {{.Pre}}</a>
+	  {{ else }}
+	  <a class="main-nav-link" href="{{ .URL }}">{{ .Name }}</a>
+	  {{ end }}
           {{ end }}
 
           {{ range .Site.Params.menu }}
           {{ if not .before }}
+	  {{ if .icon }}
+	  <a class="main-nav-link" href="{{ .link | absURL }}" title ="{{ .label }}">
+	    <i class="fa fa-{{ .icon }}"></i>
+	  </a>
+	  {{ else }}
           <td><a class="main-nav-link" href="{{ .link  | absURL }}">{{ .label }}</a></td>
+	  {{ end }}
           {{ end }}
           {{ end }}
           <td>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -543,7 +543,7 @@ code {
   -moz-appearance: textarea;
   appearance: textarea;
   padding: 0;
-  width: 200px;
+  width: 150px;
   -webkit-box-shadow: none;
   box-shadow: none;
   color: #565a5f;
@@ -596,9 +596,11 @@ code {
 #main-nav-mobile .menu .search-form-input {
   display: none;
   padding: 0 10px;
+  margin-top: 10px;
+  margin-left: 5px;
   margin-right: 15px;
-  height: 32px;
-  line-height: 32px;
+  height: 24px;
+  line-height: 24px;
   -webkit-border-radius: 16px;
   border-radius: 16px;
 }


### PR DESCRIPTION
With many menu items menu rendering breaks on mobile 

![img_2353](https://user-images.githubusercontent.com/3919652/26874771-232a627e-4b7f-11e7-998a-5ea3b0dd0dc6.png)

by allowing icons as menu items it renders like this

![img_2354](https://user-images.githubusercontent.com/3919652/26874788-34d0205e-4b7f-11e7-9cd4-6ab05b7eae67.png)

Desktop rendering is changed also by this PR

<img width="540" alt="marios_weblog" src="https://user-images.githubusercontent.com/3919652/26874850-7c51b050-4b7f-11e7-89a8-b79b66249466.png">
