### PR TITLE
Site.RegularPages instead of Data.Pages,RSSLink deprecated,UniqueID deprecated,Page .Hugo deprecated

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
             <span class="archive-category">{{ .Title }}</span>
         </div>
         <div class="archives">
-            {{ $paginator := .Paginate .Data.Pages }}
+            {{ $paginator := .Paginate .Site.RegularPages }}
             {{ range $paginator.Pages }}
                 {{ .Render "summary" }} 
             {{ end }}

--- a/layouts/partials/article_footer.html
+++ b/layouts/partials/article_footer.html
@@ -1,5 +1,5 @@
 <footer class="article-footer">
-    <a data-url="{{ .Permalink }}" data-id="{{ .UniqueID }}" class="article-share-link">
+	<a data-url="{{ .Permalink }}" data-id="{{ with .File }} {{ .UniqueID }} {{ end }} " class="article-share-link">
         <i class="fa fa-share"></i>
         {{with .Site.Data.l10n.articles.share}}{{.}}{{end}}
     </a>

--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -1,4 +1,4 @@
-{{ $paginator := .Paginate (where .Data.Pages "Section" "in" .Site.Params.mainSections) }}
+{{ $paginator := .Paginate (where .Site.RegularPages "Section" "in" .Site.Params.mainSections) }}
 {{ range $paginator.Pages }}
 <article class="article article-type-post" itemscope="" itemprop="blogPost">
     <div class="article-inner">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,7 @@
 <html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
 <head>
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} &middot; {{ .Site.Title }}{{ end }}</title>
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
@@ -11,7 +11,7 @@
     {{ else }}
       <meta name="description" content="{{ .Site.Params.site_description }}">
     {{ end }}
-    {{ with .RSSLink }}
+    {{ with .RelPermalink }}
       <link href="{{ . }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
       <link href="{{ . }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
     {{ end }}


### PR DESCRIPTION
I'm pretty sure you're aware of deprecation warning issues which started with 0.55.

`Page.Hugo is deprecated and will be removed in a future release. Use the global hugo function`, and `Page.RSSLink is deprecated and will be removed in a future release`, and ` Page.UniqueID is deprecated and will be remove`  .

But the main one - no pun intended - I wanted to bring to your attention was the `mainSections` definition from articles_list.html in which `Data.Pages` must be replaced with `Site.RepularPages`

See Your [commit](https://github.com/digitalcraftsman/hugo-icarus-theme/commit/0928ac7868816f52541d07a2a66a4038c54de344) from an earlier time, which broke recently.

