### PR TITLE
fix posts list issue

### DIFF
--- a/layouts/partials/article_list.html
+++ b/layouts/partials/article_list.html
@@ -1,4 +1,4 @@
-{{ $paginator := .Paginate (where .Data.Pages "Section" "in" .Site.Params.mainSections) }}
+{{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" site.Params.mainSections) }}
 {{ range $paginator.Pages }}
 <article class="article article-type-post" itemscope="" itemprop="blogPost">
     <div class="article-inner">


### PR DESCRIPTION
My hugo-icarus-theme site that I use has diverged quite a bit from upstream. But it was broken due to https://github.com/gohugoio/hugoThemes/issues/682 and this edit here fixed it.

This theme has been removed from the hugo theme page because this issue is unresolved. Hopefully this fixes the issue and it can be added back to the theme page!
