### PR TITLE
Fixing Gitlab social url

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ with .Site.Social.gitlab }}
-<td><a href="//gitlab.com/u/{{.}}" target="_blank" title="GitLab"><i class="fa fa-gitlab"></i></a></td>
+<td><a href="//gitlab.com/{{.}}" target="_blank" title="GitLab"><i class="fa fa-gitlab"></i></a></td>
 {{ end }}
 
 {{ with .Site.Social.bitbucket }}


### PR DESCRIPTION
Gitlab url does not work with "/u/" before id